### PR TITLE
cnchar-input 加载自定义的 dictionary

### DIFF
--- a/src/cnchar/plugin/input/cnchar.ts
+++ b/src/cnchar/plugin/input/cnchar.ts
@@ -1,15 +1,9 @@
 import ICnChar from 'cnchar-types';
-import {initSpellMap} from './util';
-import {initTradMap} from './wubi';
 
 let cnchar: ICnChar;
 
 export function setCnchar (_cnchar: ICnChar) {
     cnchar = _cnchar;
-    initSpellMap(cnchar.dict.spell);
-    if (_cnchar.hasPlugin('trad')) {
-        initTradMap(_cnchar.trad.dict?.wubi);
-    }
 }
 
 export function getCnChar (): ICnChar|null{

--- a/src/cnchar/plugin/input/dict/index.ts
+++ b/src/cnchar/plugin/input/dict/index.ts
@@ -1,0 +1,9 @@
+import dict from "./wubi.json";
+
+export function getDict() {
+  return { wubi: dict };
+}
+
+export function setDict<T>(key: string, value: T) {
+   (dict as any)[key] = value;
+}

--- a/src/cnchar/plugin/input/index.ts
+++ b/src/cnchar/plugin/input/index.ts
@@ -10,19 +10,27 @@
 import {IPlugin} from 'cnchar-types/main/common';
 import {IInput} from 'cnchar-types/plugin/input';
 import {setCnchar} from './cnchar';
-import {getDict, input} from './input';
+import {setSpellMap} from './util';
+import {setTradMap} from './wubi';
+import {input} from './input';
 
-const plugin: IPlugin & IInput = Object.assign(input, {
+/** define a custom dictionary */
+export const setDictionary = (dictionary: { spell?: Record<string, string>, wubi?: Record<string, string> }) => {
+    setSpellMap(dictionary.spell);
+    setTradMap(dictionary.wubi);
+}
+
+export const InputPlugin: IPlugin & IInput = Object.assign(input, {
     pluginName: 'input',
     install (cnchar) {
         setCnchar(cnchar);
+        
+        // make user dictionary first
+        setSpellMap(cnchar.dict.spell, false);
+        if (cnchar.hasPlugin('trad')) {
+            setTradMap(cnchar.trad.dict?.wubi, false);
+        }
     },
-    dict: getDict(),
 } as IPlugin);
 
-if (typeof window === 'object') {
-    window.CncharInput = plugin;
-    if (window.CnChar) window.CnChar.use(plugin);
-}
-
-export default plugin;
+export default InputPlugin;

--- a/src/cnchar/plugin/input/input.ts
+++ b/src/cnchar/plugin/input/input.ts
@@ -1,9 +1,9 @@
 import {mapJson} from '@common/util';
 import {IInput, IWubiCodeData} from 'cnchar-types/plugin/input';
 import {Json} from 'src/cnchar-types/main/common';
-import dict from './dict/wubi.json';
 import {spellInput} from './spell';
 import {wubiInput} from './wubi';
+import { setDict } from './dict';
 
 // 待选数组
 export const input = ((input, options = {}) => {
@@ -18,14 +18,9 @@ export const input = ((input, options = {}) => {
     return [];
 }) as IInput;
 
-export function getDict () {
-    return {wubi: dict};
-}
-
 input.setWubiCode = (words:string | Json<IWubiCodeData>, data?: IWubiCodeData) => {
     mapJson(words, data, (k, v: IWubiCodeData) => {
         const v98 =  (v.v98 === v.v86 || !v.v98) ? '' : v.v98;
-        (dict as any)[k] = `${v.v86}${v98}`;
+        setDict(k, `${v.v86}${v98}`);
     });
 };
-

--- a/src/cnchar/plugin/input/util.ts
+++ b/src/cnchar/plugin/input/util.ts
@@ -27,8 +27,10 @@ export function debounceReturn (
 
 let spellDict: Json | null = null;
 
-export function initSpellMap (dict: Json) {
-    spellDict = dict;
+export function setSpellMap (dict: Json, force = false) {
+    if (!spellDict || force) {
+        spellDict = dict;
+    }
 }
 
 export function getSpellDict () {

--- a/src/cnchar/plugin/input/wubi.ts
+++ b/src/cnchar/plugin/input/wubi.ts
@@ -7,7 +7,7 @@
 import {Json} from 'cnchar-types/main/common';
 import {IInputOptions, IInputResult} from 'cnchar-types/plugin/input';
 import {associateWubi} from './associate/ass-wubi';
-import {getDict} from './input';
+import { getDict } from './dict';
 import {debounceReturn} from './util';
 
 const Map = buildWubiMap(getDict().wubi);
@@ -16,14 +16,16 @@ let TradMap: Json | null = null;
 
 let BothMap: Json | null = null;
 
-export function initTradMap (dict: Json) {
+export function setTradMap (dict: Json, force = false) {
     if (!dict) return;
-    TradMap = buildWubiMap(dict);
-
-    BothMap = buildWubiMap({
-        ...dict,
-        ...getDict().wubi
-    });
+    if (force || !TradMap) {
+        TradMap = buildWubiMap(dict);
+        
+        BothMap = buildWubiMap({
+            ...dict,
+            ...getDict().wubi
+        });
+    }
 }
 
 function buildWubiMap (dict: Json) {


### PR DESCRIPTION
主要: 改变了 cnchar-input 的导入使用方式

```js
import cnchar from 'cnchar';
import InputPlugin, { setDictionary } from 'cnchar-input';

import CustomDictionary from 'some/where';

setDictionary({ spell: CustomDictionary });
cnchar.use(InputPlugin);
```

其他

- setSpellMap/initTradMap 重命名为 setSpellMap / setTradMap，增加 force 参数
- 优化五笔dict的使用getDict/setDict